### PR TITLE
test: add comprehensive test coverage for public API

### DIFF
--- a/Tests/ColorTests/ColorConversionTests.swift
+++ b/Tests/ColorTests/ColorConversionTests.swift
@@ -1,0 +1,500 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - HSL Conversions
+
+@Suite("HSL Conversion")
+struct HSLConversionTests {
+    @Test("Red to HSL")
+    func redToHSL() {
+        let hsl = Color.red.hsl
+        #expect(hsl.hue == 0)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("Green to HSL")
+    func greenToHSL() {
+        let hsl = Color.green.hsl
+        #expect(abs(hsl.hue - 120) < 1)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("Blue to HSL")
+    func blueToHSL() {
+        let hsl = Color.blue.hsl
+        #expect(abs(hsl.hue - 240) < 1)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("Yellow to HSL")
+    func yellowToHSL() {
+        let hsl = Color.yellow.hsl
+        #expect(abs(hsl.hue - 60) < 1)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("Cyan to HSL")
+    func cyanToHSL() {
+        let hsl = Color.cyan.hsl
+        #expect(abs(hsl.hue - 180) < 1)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("Magenta to HSL")
+    func magentaToHSL() {
+        let hsl = Color.magenta.hsl
+        #expect(abs(hsl.hue - 300) < 1)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.5)
+    }
+
+    @Test("White to HSL")
+    func whiteToHSL() {
+        let hsl = Color.white.hsl
+        #expect(hsl.saturation == 0)
+        #expect(hsl.lightness == 1.0)
+    }
+
+    @Test("Black to HSL")
+    func blackToHSL() {
+        let hsl = Color.black.hsl
+        #expect(hsl.saturation == 0)
+        #expect(hsl.lightness == 0.0)
+    }
+
+    @Test("Gray has zero saturation in HSL")
+    func grayHSL() {
+        let hsl = Color.gray.hsl
+        #expect(hsl.saturation == 0)
+        #expect(abs(hsl.lightness - 0.5) < 0.01)
+    }
+
+    @Test("HSL to Color round trip for primary colors")
+    func hslRoundTrip() {
+        for color in [Color.red, Color.green, Color.blue, Color.yellow, Color.cyan, Color.magenta] {
+            let hsl = color.hsl
+            let restored = Color(hsl: hsl)
+            #expect(abs(color.red - restored.red) < 0.01)
+            #expect(abs(color.green - restored.green) < 0.01)
+            #expect(abs(color.blue - restored.blue) < 0.01)
+        }
+    }
+
+    @Test("HSL init with parameters")
+    func hslParamInit() {
+        let color = Color(h: 0, s: 1, l: 0.5)
+        #expect(abs(color.red - 1.0) < 0.01)
+        #expect(abs(color.green) < 0.01)
+        #expect(abs(color.blue) < 0.01)
+    }
+
+    @Test("HSL init with alpha")
+    func hslWithAlpha() {
+        let color = Color(h: 120, s: 1.0, l: 0.5, a: 0.7)
+        #expect(abs(color.alpha - 0.7) < 0.01)
+        #expect(abs(color.green - 1.0) < 0.01)
+    }
+
+    @Test("HSL struct clamping")
+    func hslClamping() {
+        let hsl = HSL(h: 400, s: 1.5, l: -0.5)
+        #expect(hsl.hue >= 0 && hsl.hue < 360)
+        #expect(hsl.saturation == 1.0)
+        #expect(hsl.lightness == 0.0)
+    }
+
+    @Test("HSL achromatic conversion")
+    func hslAchromatic() {
+        let color = Color(hsl: HSL(h: 0, s: 0, l: 0.5))
+        #expect(abs(color.red - 0.5) < 0.01)
+        #expect(abs(color.green - 0.5) < 0.01)
+        #expect(abs(color.blue - 0.5) < 0.01)
+    }
+
+    @Test("HSL hue sectors cover all 60-degree ranges")
+    func hslHueSectors() {
+        // Test a color in each of the 6 hue sectors
+        let sectors: [Double] = [0, 60, 120, 180, 240, 300]
+        for hue in sectors {
+            let color = Color(h: hue + 15, s: 1.0, l: 0.5)
+            let restored = color.hsl
+            #expect(abs(restored.hue - (hue + 15)) < 2)
+        }
+    }
+}
+
+// MARK: - HSV Conversions
+
+@Suite("HSV Conversion")
+struct HSVConversionTests {
+    @Test("Red to HSV")
+    func redToHSV() {
+        let hsv = Color.red.hsv
+        #expect(hsv.hue == 0)
+        #expect(hsv.saturation == 1.0)
+        #expect(hsv.value == 1.0)
+    }
+
+    @Test("Green to HSV")
+    func greenToHSV() {
+        let hsv = Color.green.hsv
+        #expect(abs(hsv.hue - 120) < 1)
+        #expect(hsv.saturation == 1.0)
+        #expect(hsv.value == 1.0)
+    }
+
+    @Test("Blue to HSV")
+    func blueToHSV() {
+        let hsv = Color.blue.hsv
+        #expect(abs(hsv.hue - 240) < 1)
+        #expect(hsv.saturation == 1.0)
+        #expect(hsv.value == 1.0)
+    }
+
+    @Test("White to HSV")
+    func whiteToHSV() {
+        let hsv = Color.white.hsv
+        #expect(hsv.saturation == 0)
+        #expect(hsv.value == 1.0)
+    }
+
+    @Test("Black to HSV")
+    func blackToHSV() {
+        let hsv = Color.black.hsv
+        #expect(hsv.saturation == 0)
+        #expect(hsv.value == 0.0)
+    }
+
+    @Test("Gray has zero saturation in HSV")
+    func grayHSV() {
+        let hsv = Color.gray.hsv
+        #expect(hsv.saturation == 0)
+        #expect(abs(hsv.value - 0.5) < 0.01)
+    }
+
+    @Test("HSV to Color round trip for primary colors")
+    func hsvRoundTrip() {
+        for color in [Color.red, Color.green, Color.blue, Color.yellow, Color.cyan, Color.magenta] {
+            let hsv = color.hsv
+            let restored = Color(hsv: hsv)
+            #expect(abs(color.red - restored.red) < 0.01)
+            #expect(abs(color.green - restored.green) < 0.01)
+            #expect(abs(color.blue - restored.blue) < 0.01)
+        }
+    }
+
+    @Test("HSV init with parameters")
+    func hsvParamInit() {
+        let color = Color(h: 0, s: 1, v: 1)
+        #expect(abs(color.red - 1.0) < 0.01)
+        #expect(abs(color.green) < 0.01)
+        #expect(abs(color.blue) < 0.01)
+    }
+
+    @Test("HSV init with alpha")
+    func hsvWithAlpha() {
+        let color = Color(h: 240, s: 1.0, v: 1.0, a: 0.3)
+        #expect(abs(color.alpha - 0.3) < 0.01)
+        #expect(abs(color.blue - 1.0) < 0.01)
+    }
+
+    @Test("HSV struct clamping")
+    func hsvClamping() {
+        let hsv = HSV(h: 400, s: 1.5, v: -0.5)
+        #expect(hsv.hue >= 0 && hsv.hue < 360)
+        #expect(hsv.saturation == 1.0)
+        #expect(hsv.value == 0.0)
+    }
+
+    @Test("HSV achromatic conversion")
+    func hsvAchromatic() {
+        let color = Color(hsv: HSV(h: 0, s: 0, v: 0.7))
+        #expect(abs(color.red - 0.7) < 0.01)
+        #expect(abs(color.green - 0.7) < 0.01)
+        #expect(abs(color.blue - 0.7) < 0.01)
+    }
+
+    @Test("HSV hue sectors cover all 60-degree ranges")
+    func hsvHueSectors() {
+        let sectors: [Double] = [0, 60, 120, 180, 240, 300]
+        for hue in sectors {
+            let color = Color(h: hue + 15, s: 1.0, v: 1.0)
+            let restored = color.hsv
+            #expect(abs(restored.hue - (hue + 15)) < 2)
+        }
+    }
+}
+
+// MARK: - LAB Conversions
+
+@Suite("LAB Conversion")
+struct LABConversionTests {
+    @Test("Red to LAB")
+    func redToLAB() {
+        let lab = Color.red.lab
+        #expect(lab.lightness > 50)
+        #expect(lab.a > 0) // Red is positive on a axis
+        #expect(lab.b > 0) // Red is positive on b axis
+    }
+
+    @Test("Green to LAB")
+    func greenToLAB() {
+        let lab = Color.green.lab
+        #expect(lab.lightness > 80) // Green is very light
+        #expect(lab.a < 0) // Green is negative on a axis
+    }
+
+    @Test("Blue to LAB")
+    func blueToLAB() {
+        let lab = Color.blue.lab
+        #expect(lab.lightness < 40) // Blue is relatively dark
+        #expect(lab.b < 0) // Blue is negative on b axis
+    }
+
+    @Test("White to LAB")
+    func whiteToLAB() {
+        let lab = Color.white.lab
+        #expect(abs(lab.lightness - 100) < 1)
+        #expect(abs(lab.a) < 1)
+        #expect(abs(lab.b) < 1)
+    }
+
+    @Test("Black to LAB")
+    func blackToLAB() {
+        let lab = Color.black.lab
+        #expect(abs(lab.lightness) < 1)
+        #expect(abs(lab.a) < 1)
+        #expect(abs(lab.b) < 1)
+    }
+
+    @Test("LAB round trip for primary colors")
+    func labRoundTrip() {
+        for color in [Color.red, Color.green, Color.blue, Color.white, Color.black] {
+            let lab = color.lab
+            let restored = Color(lab: lab)
+            #expect(abs(color.red - restored.red) < 0.02)
+            #expect(abs(color.green - restored.green) < 0.02)
+            #expect(abs(color.blue - restored.blue) < 0.02)
+        }
+    }
+
+    @Test("LAB init with parameters")
+    func labParamInit() {
+        let color = Color(l: 50, a: 0, b: 0) // Mid gray
+        #expect(abs(color.red - color.green) < 0.01)
+        #expect(abs(color.green - color.blue) < 0.01)
+    }
+
+    @Test("LAB init with alpha")
+    func labWithAlpha() {
+        let color = Color(l: 50, a: 0, b: 0, alpha: 0.5)
+        #expect(abs(color.alpha - 0.5) < 0.01)
+    }
+
+    @Test("LAB struct initialization clamps lightness")
+    func labClamping() {
+        let lab = LAB(l: 150, a: 50, b: 50)
+        #expect(lab.lightness == 100)
+
+        let labNeg = LAB(l: -10, a: 50, b: 50)
+        #expect(labNeg.lightness == 0)
+    }
+
+    @Test("Delta E between identical colors is zero")
+    func deltaEIdentical() {
+        let de = Color.red.deltaE(from: .red)
+        #expect(abs(de) < 0.01)
+    }
+
+    @Test("Delta E between very different colors is large")
+    func deltaEDifferent() {
+        let de = Color.red.deltaE(from: .blue)
+        #expect(de > 100)
+    }
+
+    @Test("Delta E between similar colors is small")
+    func deltaESimilar() {
+        let color1 = Color(r: 1.0, g: 0.0, b: 0.0)
+        let color2 = Color(r: 0.98, g: 0.0, b: 0.0)
+        let de = color1.deltaE(from: color2)
+        #expect(de < 5)
+    }
+
+    @Test("Delta E is symmetric")
+    func deltaESymmetric() {
+        let de1 = Color.red.deltaE(from: .blue)
+        let de2 = Color.blue.deltaE(from: .red)
+        #expect(abs(de1 - de2) < 0.01)
+    }
+
+    @Test("mixLAB produces intermediate color")
+    func mixLAB() {
+        let mixed = Color.black.mixLAB(with: .white, ratio: 0.5)
+        #expect(mixed.red > 0.3 && mixed.red < 0.7)
+        #expect(mixed.green > 0.3 && mixed.green < 0.7)
+        #expect(mixed.blue > 0.3 && mixed.blue < 0.7)
+    }
+
+    @Test("mixLAB at ratio 0 returns original")
+    func mixLABZeroRatio() {
+        let mixed = Color.red.mixLAB(with: .blue, ratio: 0)
+        #expect(abs(mixed.red - Color.red.red) < 0.01)
+        #expect(abs(mixed.green - Color.red.green) < 0.01)
+        #expect(abs(mixed.blue - Color.red.blue) < 0.01)
+    }
+
+    @Test("mixLAB at ratio 1 returns other color")
+    func mixLABOneRatio() {
+        let mixed = Color.red.mixLAB(with: .blue, ratio: 1.0)
+        #expect(abs(mixed.red - Color.blue.red) < 0.02)
+        #expect(abs(mixed.green - Color.blue.green) < 0.02)
+        #expect(abs(mixed.blue - Color.blue.blue) < 0.02)
+    }
+
+    @Test("mixLAB clamps ratio")
+    func mixLABClampRatio() {
+        let mixed1 = Color.red.mixLAB(with: .blue, ratio: -0.5)
+        let mixed2 = Color.red.mixLAB(with: .blue, ratio: 0.0)
+        #expect(abs(mixed1.red - mixed2.red) < 0.01)
+
+        let mixed3 = Color.red.mixLAB(with: .blue, ratio: 1.5)
+        let mixed4 = Color.red.mixLAB(with: .blue, ratio: 1.0)
+        #expect(abs(mixed3.red - mixed4.red) < 0.01)
+    }
+
+    @Test("mixLAB interpolates alpha")
+    func mixLABAlpha() {
+        let c1 = Color.red.withAlpha(0.0)
+        let c2 = Color.blue.withAlpha(1.0)
+        let mixed = c1.mixLAB(with: c2, ratio: 0.5)
+        #expect(abs(mixed.alpha - 0.5) < 0.01)
+    }
+}
+
+// MARK: - LCH Conversions
+
+@Suite("LCH Conversion")
+struct LCHConversionTests {
+    @Test("Red to LCH")
+    func redToLCH() {
+        let lch = Color.red.lch
+        #expect(lch.lightness > 50)
+        #expect(lch.chroma > 50) // Red is highly chromatic
+        #expect(lch.hue >= 0 && lch.hue < 360)
+    }
+
+    @Test("White to LCH has zero chroma")
+    func whiteToLCH() {
+        let lch = Color.white.lch
+        #expect(abs(lch.lightness - 100) < 1)
+        #expect(abs(lch.chroma) < 1) // Achromatic
+    }
+
+    @Test("Black to LCH has zero chroma")
+    func blackToLCH() {
+        let lch = Color.black.lch
+        #expect(abs(lch.lightness) < 1)
+        #expect(abs(lch.chroma) < 1) // Achromatic
+    }
+
+    @Test("LCH round trip for primary colors")
+    func lchRoundTrip() {
+        for color in [Color.red, Color.green, Color.blue] {
+            let lch = color.lch
+            let restored = Color(lch: lch)
+            #expect(abs(color.red - restored.red) < 0.02)
+            #expect(abs(color.green - restored.green) < 0.02)
+            #expect(abs(color.blue - restored.blue) < 0.02)
+        }
+    }
+
+    @Test("LCH init with parameters")
+    func lchParamInit() {
+        let color = Color(l: 50, c: 0, h: 0)
+        // Zero chroma should produce a neutral gray
+        #expect(abs(color.red - color.green) < 0.01)
+        #expect(abs(color.green - color.blue) < 0.01)
+    }
+
+    @Test("LCH init with alpha")
+    func lchWithAlpha() {
+        let color = Color(l: 50, c: 50, h: 0, alpha: 0.6)
+        #expect(abs(color.alpha - 0.6) < 0.01)
+    }
+
+    @Test("LCH struct initialization clamps")
+    func lchClamping() {
+        let lch = LCH(l: 150, c: -10, h: 400)
+        #expect(lch.lightness == 100)
+        #expect(lch.chroma == 0)
+        #expect(lch.hue >= 0 && lch.hue < 360)
+    }
+
+    @Test("LCH is cylindrical form of LAB")
+    func lchIsLabCylindrical() {
+        let color = Color.red
+        let lab = color.lab
+        let lch = color.lch
+
+        // Lightness should match
+        #expect(abs(lab.lightness - lch.lightness) < 0.01)
+
+        // Chroma should be sqrt(a^2 + b^2)
+        let expectedChroma = sqrt(lab.a * lab.a + lab.b * lab.b)
+        #expect(abs(lch.chroma - expectedChroma) < 0.01)
+    }
+}
+
+// MARK: - Cross-Space Conversions
+
+@Suite("Cross-Space Color Conversions")
+struct CrossSpaceConversionTests {
+    @Test("HSL and HSV agree on hue for saturated colors")
+    func hslHsvHueAgreement() {
+        for color in [Color.red, Color.green, Color.blue, Color.yellow, Color.cyan, Color.magenta] {
+            let hsl = color.hsl
+            let hsv = color.hsv
+            #expect(abs(hsl.hue - hsv.hue) < 1)
+        }
+    }
+
+    @Test("HSL lightness 0 is black")
+    func hslBlack() {
+        let color = Color(h: 0, s: 1.0, l: 0.0)
+        #expect(color.red == 0.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+    }
+
+    @Test("HSL lightness 1 is white")
+    func hslWhite() {
+        let color = Color(h: 0, s: 1.0, l: 1.0)
+        #expect(abs(color.red - 1.0) < 0.01)
+        #expect(abs(color.green - 1.0) < 0.01)
+        #expect(abs(color.blue - 1.0) < 0.01)
+    }
+
+    @Test("HSV value 0 is black")
+    func hsvBlack() {
+        let color = Color(h: 0, s: 1.0, v: 0.0)
+        #expect(color.red == 0.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+    }
+
+    @Test("Round trip: RGB -> HSL -> RGB -> HSV -> RGB preserves color")
+    func multiSpaceRoundTrip() {
+        let original = Color(r: 0.3, g: 0.6, b: 0.9)
+        let viaHSL = Color(hsl: original.hsl)
+        let viaHSV = Color(hsv: viaHSL.hsv)
+        #expect(abs(original.red - viaHSV.red) < 0.02)
+        #expect(abs(original.green - viaHSV.green) < 0.02)
+        #expect(abs(original.blue - viaHSV.blue) < 0.02)
+    }
+}

--- a/Tests/ColorTests/ColorEdgeCaseTests.swift
+++ b/Tests/ColorTests/ColorEdgeCaseTests.swift
@@ -1,0 +1,583 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - Alpha Preservation Through Operations
+
+@Suite("Alpha Preservation")
+struct AlphaPreservationTests {
+    @Test("Lighten preserves alpha")
+    func lightenAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        let lighter = color.lighten(by: 0.2)
+        #expect(abs(lighter.alpha - 0.3) < 0.01)
+    }
+
+    @Test("Darken preserves alpha")
+    func darkenAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        let darker = color.darken(by: 0.2)
+        #expect(abs(darker.alpha - 0.3) < 0.01)
+    }
+
+    @Test("Saturate preserves alpha")
+    func saturateAlpha() {
+        let color = Color(h: 0, s: 0.5, l: 0.5, a: 0.4)
+        let saturated = color.saturate(by: 0.2)
+        #expect(abs(saturated.alpha - 0.4) < 0.01)
+    }
+
+    @Test("Desaturate preserves alpha")
+    func desaturateAlpha() {
+        let color = Color.red.withAlpha(0.6)
+        let desaturated = color.desaturate(by: 0.2)
+        #expect(abs(desaturated.alpha - 0.6) < 0.01)
+    }
+
+    @Test("Invert preserves alpha")
+    func invertAlpha() {
+        let color = Color.red.withAlpha(0.7)
+        let inverted = color.inverted
+        #expect(abs(inverted.alpha - 0.7) < 0.01)
+    }
+
+    @Test("Complement preserves alpha")
+    func complementAlpha() {
+        let color = Color.red.withAlpha(0.8)
+        let comp = color.complement
+        #expect(abs(comp.alpha - 0.8) < 0.01)
+    }
+
+    @Test("AdjustHue preserves alpha")
+    func adjustHueAlpha() {
+        let color = Color.red.withAlpha(0.4)
+        let adjusted = color.adjustHue(by: 90)
+        #expect(abs(adjusted.alpha - 0.4) < 0.01)
+    }
+
+    @Test("Grayscale preserves alpha")
+    func grayscaleAlpha() {
+        let color = Color.red.withAlpha(0.5)
+        let gray = color.grayscale
+        #expect(abs(gray.alpha - 0.5) < 0.01)
+    }
+
+    @Test("Multiply preserves source alpha")
+    func multiplyAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        let result = color.multiply(with: .blue)
+        #expect(abs(result.alpha - 0.3) < 0.01)
+    }
+
+    @Test("Screen preserves source alpha")
+    func screenAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        let result = color.screen(with: .blue)
+        #expect(abs(result.alpha - 0.3) < 0.01)
+    }
+
+    @Test("Overlay preserves source alpha")
+    func overlayAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        let result = color.overlay(with: .blue)
+        #expect(abs(result.alpha - 0.3) < 0.01)
+    }
+}
+
+// MARK: - Manipulation Edge Cases
+
+@Suite("Manipulation Edge Cases")
+struct ManipulationEdgeCaseTests {
+    @Test("Lighten by zero produces same color")
+    func lightenByZero() {
+        let color = Color.red
+        let lightened = color.lighten(by: 0.0)
+        #expect(abs(lightened.red - color.red) < 0.01)
+    }
+
+    @Test("Darken by zero produces same color")
+    func darkenByZero() {
+        let color = Color.red
+        let darkened = color.darken(by: 0.0)
+        #expect(abs(darkened.red - color.red) < 0.01)
+    }
+
+    @Test("Lighten white stays white")
+    func lightenWhite() {
+        let lightened = Color.white.lighten(by: 0.5)
+        #expect(lightened.hsl.lightness == 1.0)
+    }
+
+    @Test("Darken black stays black")
+    func darkenBlack() {
+        let darkened = Color.black.darken(by: 0.5)
+        #expect(darkened.hsl.lightness == 0.0)
+    }
+
+    @Test("Invert twice returns original")
+    func invertTwice() {
+        let original = Color(r: 0.3, g: 0.6, b: 0.9)
+        let doubleInverted = original.inverted.inverted
+        #expect(abs(original.red - doubleInverted.red) < 0.01)
+        #expect(abs(original.green - doubleInverted.green) < 0.01)
+        #expect(abs(original.blue - doubleInverted.blue) < 0.01)
+    }
+
+    @Test("Invert black gives white")
+    func invertBlack() {
+        let inverted = Color.black.inverted
+        #expect(inverted.red == 1.0)
+        #expect(inverted.green == 1.0)
+        #expect(inverted.blue == 1.0)
+    }
+
+    @Test("Invert white gives black")
+    func invertWhite() {
+        let inverted = Color.white.inverted
+        #expect(inverted.red == 0.0)
+        #expect(inverted.green == 0.0)
+        #expect(inverted.blue == 0.0)
+    }
+
+    @Test("Mix at ratio 0 returns first color")
+    func mixRatioZero() {
+        let mixed = Color.red.mix(with: .blue, ratio: 0.0)
+        #expect(mixed.red == 1.0)
+        #expect(mixed.blue == 0.0)
+    }
+
+    @Test("Mix at ratio 1 returns second color")
+    func mixRatioOne() {
+        let mixed = Color.red.mix(with: .blue, ratio: 1.0)
+        #expect(mixed.red == 0.0)
+        #expect(mixed.blue == 1.0)
+    }
+
+    @Test("Mix clamps ratio below 0")
+    func mixClampBelow() {
+        let mixed1 = Color.red.mix(with: .blue, ratio: -0.5)
+        let mixed2 = Color.red.mix(with: .blue, ratio: 0.0)
+        #expect(abs(mixed1.red - mixed2.red) < 0.01)
+    }
+
+    @Test("Mix clamps ratio above 1")
+    func mixClampAbove() {
+        let mixed1 = Color.red.mix(with: .blue, ratio: 1.5)
+        let mixed2 = Color.red.mix(with: .blue, ratio: 1.0)
+        #expect(abs(mixed1.red - mixed2.red) < 0.01)
+    }
+
+    @Test("Mix interpolates alpha")
+    func mixAlpha() {
+        let c1 = Color.red.withAlpha(0.0)
+        let c2 = Color.blue.withAlpha(1.0)
+        let mixed = c1.mix(with: c2, ratio: 0.5)
+        #expect(abs(mixed.alpha - 0.5) < 0.01)
+    }
+
+    @Test("Complement of complement returns original hue")
+    func doubleComplement() {
+        let original = Color(h: 45, s: 1.0, l: 0.5)
+        let doubleComp = original.complement.complement
+        #expect(abs(doubleComp.hsl.hue - 45) < 2)
+    }
+
+    @Test("AdjustHue by 360 returns same hue")
+    func adjustHue360() {
+        let original = Color(h: 90, s: 1.0, l: 0.5)
+        let adjusted = original.adjustHue(by: 360)
+        #expect(abs(adjusted.hsl.hue - 90) < 2)
+    }
+
+    @Test("AdjustHue by negative degrees")
+    func adjustHueNegative() {
+        let original = Color(h: 90, s: 1.0, l: 0.5)
+        let adjusted = original.adjustHue(by: -90)
+        #expect(abs(adjusted.hsl.hue - 0) < 2 || abs(adjusted.hsl.hue - 360) < 2)
+    }
+
+    @Test("Tint at 0 returns original")
+    func tintAtZero() {
+        let tinted = Color.red.tint(by: 0.0)
+        #expect(tinted.red == 1.0)
+        #expect(tinted.green == 0.0)
+        #expect(tinted.blue == 0.0)
+    }
+
+    @Test("Tint at 1 returns white")
+    func tintAtOne() {
+        let tinted = Color.red.tint(by: 1.0)
+        #expect(tinted.red == 1.0)
+        #expect(tinted.green == 1.0)
+        #expect(tinted.blue == 1.0)
+    }
+
+    @Test("Shade at 0 returns original")
+    func shadeAtZero() {
+        let shaded = Color.red.shade(by: 0.0)
+        #expect(shaded.red == 1.0)
+        #expect(shaded.green == 0.0)
+        #expect(shaded.blue == 0.0)
+    }
+
+    @Test("Shade at 1 returns black")
+    func shadeAtOne() {
+        let shaded = Color.red.shade(by: 1.0)
+        #expect(shaded.red == 0.0)
+        #expect(shaded.green == 0.0)
+        #expect(shaded.blue == 0.0)
+    }
+
+    @Test("Desaturate fully produces gray")
+    func desaturateFully() {
+        let gray = Color.red.desaturate(by: 1.0)
+        #expect(gray.hsl.saturation == 0)
+    }
+
+    @Test("Default lighten amount is 0.1")
+    func lightenDefault() {
+        let hsl = Color.red.hsl
+        let lightened = Color.red.lighten()
+        #expect(abs(lightened.hsl.lightness - (hsl.lightness + 0.1)) < 0.01)
+    }
+
+    @Test("Default darken amount is 0.1")
+    func darkenDefault() {
+        let hsl = Color.red.hsl
+        let darkened = Color.red.darken()
+        #expect(abs(darkened.hsl.lightness - (hsl.lightness - 0.1)) < 0.01)
+    }
+}
+
+// MARK: - Blend Mode Edge Cases
+
+@Suite("Blend Mode Edge Cases")
+struct BlendModeEdgeCaseTests {
+    @Test("Multiply with black gives black")
+    func multiplyBlack() {
+        let result = Color.red.multiply(with: .black)
+        #expect(result.red == 0.0)
+        #expect(result.green == 0.0)
+        #expect(result.blue == 0.0)
+    }
+
+    @Test("Multiply with white is identity")
+    func multiplyWhite() {
+        let result = Color.red.multiply(with: .white)
+        #expect(result.red == 1.0)
+        #expect(result.green == 0.0)
+        #expect(result.blue == 0.0)
+    }
+
+    @Test("Screen with white gives white")
+    func screenWhite() {
+        let result = Color.red.screen(with: .white)
+        #expect(result.red == 1.0)
+        #expect(result.green == 1.0)
+        #expect(result.blue == 1.0)
+    }
+
+    @Test("Screen with black is identity")
+    func screenBlack() {
+        let result = Color.red.screen(with: .black)
+        #expect(result.red == 1.0)
+        #expect(result.green == 0.0)
+        #expect(result.blue == 0.0)
+    }
+
+    @Test("Multiply is commutative")
+    func multiplyCommutative() {
+        let a = Color(r: 0.3, g: 0.6, b: 0.9)
+        let b = Color(r: 0.8, g: 0.4, b: 0.2)
+        let ab = a.multiply(with: b)
+        let ba = b.multiply(with: a)
+        #expect(abs(ab.red - ba.red) < 0.01)
+        #expect(abs(ab.green - ba.green) < 0.01)
+        #expect(abs(ab.blue - ba.blue) < 0.01)
+    }
+
+    @Test("Screen is commutative")
+    func screenCommutative() {
+        let a = Color(r: 0.3, g: 0.6, b: 0.9)
+        let b = Color(r: 0.8, g: 0.4, b: 0.2)
+        let ab = a.screen(with: b)
+        let ba = b.screen(with: a)
+        #expect(abs(ab.red - ba.red) < 0.01)
+        #expect(abs(ab.green - ba.green) < 0.01)
+        #expect(abs(ab.blue - ba.blue) < 0.01)
+    }
+
+    @Test("Overlay with gray is meaningful")
+    func overlayGray() {
+        let result = Color.gray.overlay(with: .red)
+        #expect(result.red > 0)
+        #expect(result.red <= 1.0)
+    }
+}
+
+// MARK: - Accessibility Edge Cases
+
+@Suite("Accessibility Edge Cases")
+struct AccessibilityEdgeCaseTests {
+    @Test("Black on white passes all levels")
+    func blackOnWhite() {
+        #expect(Color.black.isAccessible(on: .white, level: .aa))
+        #expect(Color.black.isAccessible(on: .white, level: .aaa))
+        #expect(Color.black.isAccessible(on: .white, level: .aa, largeText: true))
+        #expect(Color.black.isAccessible(on: .white, level: .aaa, largeText: true))
+    }
+
+    @Test("White luminance is 1.0")
+    func whiteLuminance() {
+        #expect(Color.white.luminance == 1.0)
+    }
+
+    @Test("Black luminance is 0.0")
+    func blackLuminance() {
+        #expect(Color.black.luminance == 0.0)
+    }
+
+    @Test("Contrast ratio is symmetric")
+    func contrastSymmetric() {
+        let ratio1 = Color.red.contrastRatio(with: .white)
+        let ratio2 = Color.white.contrastRatio(with: .red)
+        #expect(abs(ratio1 - ratio2) < 0.01)
+    }
+
+    @Test("Same color contrast ratio is 1")
+    func sameColorContrast() {
+        let ratio = Color.red.contrastRatio(with: .red)
+        #expect(abs(ratio - 1.0) < 0.01)
+    }
+
+    @Test("Black/white max contrast ratio is 21")
+    func maxContrastRatio() {
+        let ratio = Color.black.contrastRatio(with: .white)
+        #expect(abs(ratio - 21.0) < 0.1)
+    }
+
+    @Test("Contrasting text for dark backgrounds is white")
+    func darkBackgroundText() {
+        #expect(Color.black.contrastingTextColor == .white)
+        #expect(Color(hex: "#333333")!.contrastingTextColor == .white)
+    }
+
+    @Test("Contrasting text for light backgrounds is black")
+    func lightBackgroundText() {
+        #expect(Color.white.contrastingTextColor == .black)
+        #expect(Color(hex: "#CCCCCC")!.contrastingTextColor == .black)
+    }
+
+    @Test("adjustedForAccessibility returns self when already accessible")
+    func alreadyAccessible() {
+        let result = Color.black.adjustedForAccessibility(on: .white, level: .aa)
+        #expect(result == Color.black)
+    }
+
+    @Test("adjustedForAccessibility finds accessible color")
+    func findsAccessible() {
+        let color = Color(hex: "#777777")!
+        let adjusted = color.adjustedForAccessibility(on: .white, level: .aa)
+        #expect(adjusted != nil)
+        #expect(adjusted!.isAccessible(on: .white, level: .aa))
+    }
+
+    @Test("Large text has lower contrast requirements")
+    func largeTextLowerRequirements() {
+        let color = Color(hex: "#888888")!
+        let passesLarge = color.isAccessible(on: .white, level: .aa, largeText: true)
+        let passesNormal = color.isAccessible(on: .white, level: .aa, largeText: false)
+        // Large text should be same or easier to pass
+        #expect(passesLarge || !passesNormal)
+    }
+}
+
+// MARK: - Color Blindness Simulation Edge Cases
+
+@Suite("Color Blindness Edge Cases")
+struct ColorBlindnessEdgeCaseTests {
+    @Test("Black remains black in all simulations")
+    func blackUnchanged() {
+        let proto = Color.black.simulatedProtanopia
+        let deut = Color.black.simulatedDeuteranopia
+        let trit = Color.black.simulatedTritanopia
+        #expect(proto.red < 0.01 && proto.green < 0.01 && proto.blue < 0.01)
+        #expect(deut.red < 0.01 && deut.green < 0.01 && deut.blue < 0.01)
+        #expect(trit.red < 0.01 && trit.green < 0.01 && trit.blue < 0.01)
+    }
+
+    @Test("White remains approximately white in all simulations")
+    func whiteApproxUnchanged() {
+        let proto = Color.white.simulatedProtanopia
+        let deut = Color.white.simulatedDeuteranopia
+        let trit = Color.white.simulatedTritanopia
+        #expect(proto.red > 0.9)
+        #expect(deut.red > 0.9)
+        #expect(trit.red > 0.9)
+    }
+
+    @Test("Simulations preserve alpha")
+    func simulationsPreserveAlpha() {
+        let color = Color.red.withAlpha(0.3)
+        #expect(abs(color.simulatedProtanopia.alpha - 0.3) < 0.01)
+        #expect(abs(color.simulatedDeuteranopia.alpha - 0.3) < 0.01)
+        #expect(abs(color.simulatedTritanopia.alpha - 0.3) < 0.01)
+    }
+}
+
+// MARK: - Palette Edge Cases
+
+@Suite("Palette Edge Cases")
+struct PaletteEdgeCaseTests {
+    @Test("Complementary always returns 2 colors")
+    func complementaryCount() {
+        #expect(Color.red.complementary.count == 2)
+        #expect(Color.black.complementary.count == 2)
+        #expect(Color.white.complementary.count == 2)
+    }
+
+    @Test("Triadic always returns 3 colors")
+    func triadicCount() {
+        #expect(Color.red.triadic.count == 3)
+        #expect(Color.black.triadic.count == 3)
+    }
+
+    @Test("Tetradic always returns 4 colors")
+    func tetradicCount() {
+        #expect(Color.red.tetradic.count == 4)
+        #expect(Color.black.tetradic.count == 4)
+    }
+
+    @Test("Split complementary always returns 3 colors")
+    func splitCompCount() {
+        #expect(Color.red.splitComplementary.count == 3)
+    }
+
+    @Test("Analogous respects count parameter")
+    func analogousCount() {
+        #expect(Color.red.analogous(count: 1).count == 1)
+        #expect(Color.red.analogous(count: 5).count == 5)
+        #expect(Color.red.analogous(count: 10).count == 10)
+    }
+
+    @Test("Gradient with 2 steps returns start and end")
+    func gradient2Steps() {
+        let colors = Color.red.gradient(to: .blue, steps: 2)
+        #expect(colors.count == 2)
+        #expect(colors[0].red > 0.9)
+        // Last should be approximately blue
+        #expect(colors[1].blue > 0.9)
+    }
+
+    @Test("Gradient with 1 step returns self")
+    func gradient1Step() {
+        let colors = Color.red.gradient(to: .blue, steps: 1)
+        #expect(colors.count == 1)
+        #expect(colors[0].red == 1.0)
+    }
+
+    @Test("Tints first is original, last is white")
+    func tintsFirstLast() {
+        let tints = Color.blue.tints(count: 5)
+        #expect(tints.first!.blue > 0.9)
+        #expect(tints.last!.red == 1.0)
+        #expect(tints.last!.green == 1.0)
+        #expect(tints.last!.blue == 1.0)
+    }
+
+    @Test("Shades first is original, last is black")
+    func shadesFirstLast() {
+        let shades = Color.blue.shades(count: 5)
+        #expect(shades.first!.blue > 0.9)
+        #expect(shades.last!.red == 0.0)
+        #expect(shades.last!.green == 0.0)
+        #expect(shades.last!.blue == 0.0)
+    }
+
+    @Test("Tonal scale goes from dark to light")
+    func tonalScaleMonotone() {
+        let scale = Color.red.tonalScale(count: 9)
+        #expect(scale.count == 9)
+        #expect(scale.first!.luminance < scale.last!.luminance)
+    }
+
+    @Test("Random color is valid")
+    func randomValid() {
+        let color = Color.random()
+        #expect(color.red >= 0 && color.red <= 1)
+        #expect(color.green >= 0 && color.green <= 1)
+        #expect(color.blue >= 0 && color.blue <= 1)
+        #expect(color.alpha == 1.0)
+    }
+
+    @Test("Random with alpha respects parameter")
+    func randomAlpha() {
+        let color = Color.random(alpha: 0.5)
+        #expect(color.alpha == 0.5)
+    }
+
+    @Test("Distinct palette produces unique colors")
+    func distinctPaletteUnique() {
+        let colors = Color.distinctPalette(count: 10)
+        #expect(colors.count == 10)
+        for i in 0..<colors.count {
+            for j in (i + 1)..<colors.count {
+                #expect(colors[i] != colors[j])
+            }
+        }
+    }
+
+    @Test("Multi-gradient produces correct count")
+    func multiGradientCount() {
+        let colors = Color.red.multiGradient(through: [.yellow, .blue], stepsPerSegment: 5)
+        // 5 for first segment minus last + 5 for second segment = 4 + 5 = 9
+        #expect(colors.count == 9)
+    }
+
+    @Test("Non-perceptual gradient differs from perceptual")
+    func perceptualVsLinear() {
+        let perceptual = Color.red.gradient(to: .blue, steps: 5, perceptual: true)
+        let linear = Color.red.gradient(to: .blue, steps: 5, perceptual: false)
+        // Both should have 5 colors
+        #expect(perceptual.count == 5)
+        #expect(linear.count == 5)
+        // Middle colors may differ
+        // (We just check both produce valid results)
+        for color in perceptual + linear {
+            #expect(color.red >= 0 && color.red <= 1)
+            #expect(color.green >= 0 && color.green <= 1)
+            #expect(color.blue >= 0 && color.blue <= 1)
+        }
+    }
+}
+
+// MARK: - Grayscale Edge Cases
+
+@Suite("Grayscale Edge Cases")
+struct GrayscaleEdgeCaseTests {
+    @Test("Grayscale of gray is the same gray")
+    func grayGrayscale() {
+        let gray = Color.gray.grayscale
+        #expect(abs(gray.red - gray.green) < 0.01)
+        #expect(abs(gray.green - gray.blue) < 0.01)
+    }
+
+    @Test("Grayscale of white is white")
+    func whiteGrayscale() {
+        let gray = Color.white.grayscale
+        #expect(abs(gray.red - 1.0) < 0.01)
+    }
+
+    @Test("Grayscale of black is black")
+    func blackGrayscale() {
+        let gray = Color.black.grayscale
+        #expect(abs(gray.red) < 0.01)
+    }
+
+    @Test("Grayscale produces equal RGB components")
+    func grayscaleEqualComponents() {
+        let gray = Color(r: 0.3, g: 0.6, b: 0.9).grayscale
+        #expect(abs(gray.red - gray.green) < 0.01)
+        #expect(abs(gray.green - gray.blue) < 0.01)
+    }
+}

--- a/Tests/ColorTests/ColorHexCSSTests.swift
+++ b/Tests/ColorTests/ColorHexCSSTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - Hex Parsing
+
+@Suite("Hex String Parsing")
+struct HexParsingTests {
+    @Test("6-character hex with hash")
+    func hex6WithHash() {
+        let color = Color(hex: "#FF0000")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.green == 0.0)
+        #expect(color?.blue == 0.0)
+        #expect(color?.alpha == 1.0)
+    }
+
+    @Test("6-character hex without hash")
+    func hex6WithoutHash() {
+        let color = Color(hex: "00FF00")
+        #expect(color != nil)
+        #expect(color?.green == 1.0)
+    }
+
+    @Test("6-character hex with 0x prefix")
+    func hex6With0x() {
+        let color = Color(hex: "0x0000FF")
+        #expect(color != nil)
+        #expect(color?.blue == 1.0)
+    }
+
+    @Test("6-character hex with 0X prefix (uppercase)")
+    func hex6With0XUppercase() {
+        let color = Color(hex: "0XFF0000")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+    }
+
+    @Test("3-character shorthand")
+    func hex3Shorthand() {
+        let color = Color(hex: "#F00")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.green == 0.0)
+        #expect(color?.blue == 0.0)
+    }
+
+    @Test("3-character shorthand expansion")
+    func hex3Expansion() {
+        // #ABC should expand to #AABBCC
+        let color = Color(hex: "#ABC")
+        #expect(color != nil)
+        #expect(color?.red8 == 0xAA)
+        #expect(color?.green8 == 0xBB)
+        #expect(color?.blue8 == 0xCC)
+    }
+
+    @Test("4-character shorthand with alpha")
+    func hex4Shorthand() {
+        let color = Color(hex: "#F00F")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.alpha == 1.0)
+    }
+
+    @Test("4-character shorthand half alpha")
+    func hex4HalfAlpha() {
+        // #F008 -> FF000088 -> alpha = 0x88/255 ≈ 0.533
+        let color = Color(hex: "#F008")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(abs((color?.alpha ?? 0) - Double(0x88) / 255.0) < 0.01)
+    }
+
+    @Test("8-character hex with alpha")
+    func hex8WithAlpha() {
+        let color = Color(hex: "#FF000080")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(abs((color?.alpha ?? 0) - 0.502) < 0.01)
+    }
+
+    @Test("8-character hex full alpha")
+    func hex8FullAlpha() {
+        let color = Color(hex: "#FF0000FF")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.alpha == 1.0)
+    }
+
+    @Test("8-character hex zero alpha")
+    func hex8ZeroAlpha() {
+        let color = Color(hex: "#FF000000")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.alpha == 0.0)
+    }
+
+    @Test("Lowercase hex is valid")
+    func lowercaseHex() {
+        let color = Color(hex: "#ff0000")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+    }
+
+    @Test("Mixed case hex is valid")
+    func mixedCaseHex() {
+        let color = Color(hex: "#Ff00fF")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.blue == 1.0)
+    }
+
+    @Test("Whitespace is trimmed")
+    func whitespaceTrimmed() {
+        let color = Color(hex: "  #FF0000  ")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+    }
+
+    @Test("Invalid hex returns nil")
+    func invalidHex() {
+        #expect(Color(hex: "invalid") == nil)
+        #expect(Color(hex: "#GG0000") == nil)
+        #expect(Color(hex: "#FF") == nil)
+        #expect(Color(hex: "#FFFFF") == nil) // 5 chars
+        #expect(Color(hex: "#FFFFFFFFF") == nil) // 9 chars
+        #expect(Color(hex: "") == nil)
+        #expect(Color(hex: "#") == nil)
+    }
+
+    @Test("Known color hex values")
+    func knownHexValues() {
+        #expect(Color(hex: "#808080")?.red8 == 128)
+        #expect(Color(hex: "#808080")?.green8 == 128)
+        #expect(Color(hex: "#808080")?.blue8 == 128)
+
+        #expect(Color(hex: "#C0C0C0")?.red8 == 192)
+    }
+}
+
+// MARK: - Hex Output
+
+@Suite("Hex String Output")
+struct HexOutputTests {
+    @Test("Opaque color outputs 6-char hex")
+    func opaqueHex() {
+        #expect(Color.red.hex == "#FF0000")
+        #expect(Color.green.hex == "#00FF00")
+        #expect(Color.blue.hex == "#0000FF")
+        #expect(Color.white.hex == "#FFFFFF")
+        #expect(Color.black.hex == "#000000")
+    }
+
+    @Test("Color with alpha outputs 8-char hex")
+    func alphaHex() {
+        let color = Color.red.withAlpha(0.5)
+        #expect(color.hex.count == 9) // # + 8 chars
+        #expect(color.hex.hasPrefix("#FF0000"))
+    }
+
+    @Test("hexValue has no hash prefix")
+    func hexValueNoPrefix() {
+        #expect(Color.red.hexValue == "FF0000")
+        #expect(!Color.red.hexValue.contains("#"))
+    }
+
+    @Test("hexValue with alpha has no hash prefix")
+    func hexValueAlphaNoPrefix() {
+        let color = Color.red.withAlpha(0.5)
+        #expect(!color.hexValue.contains("#"))
+        #expect(color.hexValue.hasPrefix("FF0000"))
+    }
+
+    @Test("Hex round trip")
+    func hexRoundTrip() {
+        let hexValues = ["#FF0000", "#00FF00", "#0000FF", "#FFFFFF", "#000000", "#808080"]
+        for hex in hexValues {
+            let color = Color(hex: hex)!
+            #expect(color.hex == hex)
+        }
+    }
+}
+
+// MARK: - CSS rgb()/rgba() Format
+
+@Suite("CSS RGB Format")
+struct CSSRGBFormatTests {
+    @Test("Opaque color CSS output")
+    func opaqueCSS() {
+        #expect(Color.red.css == "rgb(255, 0, 0)")
+        #expect(Color.blue.css == "rgb(0, 0, 255)")
+        #expect(Color.white.css == "rgb(255, 255, 255)")
+        #expect(Color.black.css == "rgb(0, 0, 0)")
+    }
+
+    @Test("Color with alpha CSS output")
+    func alphaCSS() {
+        let color = Color.red.withAlpha(0.5)
+        #expect(color.css.contains("rgba"))
+        #expect(color.css.contains("255"))
+        #expect(color.css.contains("0.50"))
+    }
+
+    @Test("Parse rgb() string")
+    func parseRGB() {
+        let color = Color(css: "rgb(255, 128, 0)")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(abs((color?.green ?? 0) - 128.0 / 255.0) < 0.01)
+        #expect(color?.blue == 0.0)
+    }
+
+    @Test("Parse rgba() string")
+    func parseRGBA() {
+        let color = Color(css: "rgba(255, 0, 0, 0.5)")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(abs((color?.alpha ?? 0) - 0.5) < 0.01)
+    }
+
+    @Test("Parse rgb() with spaces")
+    func parseWithSpaces() {
+        let color = Color(css: "  rgb( 255 , 0 , 0 )  ")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+    }
+
+    @Test("Parse rgb() with zero values")
+    func parseZero() {
+        let color = Color(css: "rgb(0, 0, 0)")
+        #expect(color != nil)
+        #expect(color?.red == 0.0)
+        #expect(color?.green == 0.0)
+        #expect(color?.blue == 0.0)
+    }
+
+    @Test("Parse rgb() with max values")
+    func parseMax() {
+        let color = Color(css: "rgb(255, 255, 255)")
+        #expect(color != nil)
+        #expect(color?.red == 1.0)
+        #expect(color?.green == 1.0)
+        #expect(color?.blue == 1.0)
+    }
+
+    @Test("Invalid CSS returns nil")
+    func invalidCSS() {
+        #expect(Color(css: "not-a-color") == nil)
+        #expect(Color(css: "rgb(abc, 0, 0)") == nil)
+        #expect(Color(css: "hsl(0, 100%, 50%)") == nil) // CSS parse only handles rgb/rgba
+        #expect(Color(css: "") == nil)
+    }
+
+    @Test("CSS round trip")
+    func cssRoundTrip() {
+        let original = Color(r: 255, g: 128, b: 0)
+        let css = original.css
+        let restored = Color(css: css)
+        #expect(restored != nil)
+        #expect(restored?.red8 == original.red8)
+        #expect(restored?.green8 == original.green8)
+        #expect(restored?.blue8 == original.blue8)
+    }
+}
+
+// MARK: - CSS hsl()/hsla() Format
+
+@Suite("CSS HSL Format")
+struct CSSHSLFormatTests {
+    @Test("Opaque color cssHSL output")
+    func opaqueCSSHSL() {
+        let css = Color.red.cssHSL
+        #expect(css.hasPrefix("hsl("))
+        #expect(css.contains("0"))
+        #expect(css.contains("100%"))
+        #expect(css.contains("50%"))
+    }
+
+    @Test("Color with alpha cssHSL output")
+    func alphaCSSHSL() {
+        let color = Color.red.withAlpha(0.5)
+        let css = color.cssHSL
+        #expect(css.hasPrefix("hsla("))
+        #expect(css.contains("0.50"))
+    }
+
+    @Test("Blue cssHSL has hue 240")
+    func blueCSSHSL() {
+        let css = Color.blue.cssHSL
+        #expect(css.contains("240"))
+    }
+
+    @Test("Green cssHSL has hue 120")
+    func greenCSSHSL() {
+        let css = Color.green.cssHSL
+        #expect(css.contains("120"))
+    }
+
+    @Test("Gray cssHSL has 0% saturation")
+    func grayCSSHSL() {
+        let css = Color.gray.cssHSL
+        #expect(css.contains("0%"))
+    }
+}

--- a/Tests/ColorTests/ColorProtocolTests.swift
+++ b/Tests/ColorTests/ColorProtocolTests.swift
@@ -1,0 +1,410 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - Equatable Conformance
+
+@Suite("Equatable Conformance")
+struct EquatableTests {
+    @Test("Same colors are equal")
+    func sameColorsEqual() {
+        let a = Color(r: 0.5, g: 0.3, b: 0.7, a: 0.9)
+        let b = Color(r: 0.5, g: 0.3, b: 0.7, a: 0.9)
+        #expect(a == b)
+    }
+
+    @Test("Different colors are not equal")
+    func differentColorsNotEqual() {
+        #expect(Color.red != Color.blue)
+        #expect(Color.red != Color.green)
+        #expect(Color.white != Color.black)
+    }
+
+    @Test("Colors differing only in alpha are not equal")
+    func alphaDifference() {
+        let opaque = Color(r: 1.0, g: 0.0, b: 0.0, a: 1.0)
+        let transparent = Color(r: 1.0, g: 0.0, b: 0.0, a: 0.5)
+        #expect(opaque != transparent)
+    }
+
+    @Test("Static colors equal themselves")
+    func staticSelfEquality() {
+        #expect(Color.red == Color.red)
+        #expect(Color.blue == Color.blue)
+        #expect(Color.black == Color.black)
+        #expect(Color.white == Color.white)
+        #expect(Color.clear == Color.clear)
+    }
+
+    @Test("Colors from different init paths are equal")
+    func differentInitPathsEqual() {
+        let fromDouble = Color(r: 1.0, g: 0.0, b: 0.0)
+        let fromHex = Color(hex: "#FF0000")!
+        #expect(fromDouble == fromHex)
+    }
+}
+
+// MARK: - Hashable Conformance
+
+@Suite("Hashable Conformance")
+struct HashableTests {
+    @Test("Equal colors have same hash")
+    func equalColorsHashEqual() {
+        let a = Color(r: 0.5, g: 0.3, b: 0.7)
+        let b = Color(r: 0.5, g: 0.3, b: 0.7)
+        #expect(a.hashValue == b.hashValue)
+    }
+
+    @Test("Color as dictionary key")
+    func dictionaryKey() {
+        var dict: [Color: String] = [:]
+        dict[.red] = "red"
+        dict[.blue] = "blue"
+        dict[.green] = "green"
+        #expect(dict.count == 3)
+        #expect(dict[.red] == "red")
+        #expect(dict[.blue] == "blue")
+        #expect(dict[.green] == "green")
+    }
+
+    @Test("Color in Set")
+    func colorInSet() {
+        var set = Set<Color>()
+        set.insert(.red)
+        set.insert(.blue)
+        set.insert(.green)
+        #expect(set.count == 3)
+        #expect(set.contains(.red))
+        #expect(set.contains(.blue))
+        #expect(set.contains(.green))
+    }
+
+    @Test("Set deduplicates equal colors")
+    func setDeduplication() {
+        var set = Set<Color>()
+        set.insert(Color(r: 1.0, g: 0.0, b: 0.0))
+        set.insert(Color(r: 1.0, g: 0.0, b: 0.0))
+        set.insert(Color.red)
+        #expect(set.count == 1)
+    }
+
+    @Test("HSL struct is Hashable")
+    func hslHashable() {
+        let a = HSL(h: 0, s: 1, l: 0.5)
+        let b = HSL(h: 0, s: 1, l: 0.5)
+        #expect(a.hashValue == b.hashValue)
+
+        var set = Set<HSL>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+
+    @Test("HSV struct is Hashable")
+    func hsvHashable() {
+        let a = HSV(h: 120, s: 1, v: 1)
+        let b = HSV(h: 120, s: 1, v: 1)
+        #expect(a.hashValue == b.hashValue)
+
+        var set = Set<HSV>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+
+    @Test("LAB struct is Hashable")
+    func labHashable() {
+        let a = LAB(l: 50, a: 25, b: -10)
+        let b = LAB(l: 50, a: 25, b: -10)
+        #expect(a.hashValue == b.hashValue)
+
+        var set = Set<LAB>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+
+    @Test("LCH struct is Hashable")
+    func lchHashable() {
+        let a = LCH(l: 50, c: 30, h: 180)
+        let b = LCH(l: 50, c: 30, h: 180)
+        #expect(a.hashValue == b.hashValue)
+
+        var set = Set<LCH>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+}
+
+// MARK: - Codable Conformance
+
+@Suite("Codable Conformance")
+struct CodableTests {
+    @Test("Encode and decode Color")
+    func codableRoundTrip() throws {
+        let original = Color(r: 0.5, g: 0.25, b: 0.75, a: 0.9)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+        #expect(decoded == original)
+    }
+
+    @Test("Encode pure red")
+    func encodePureRed() throws {
+        let encoded = try JSONEncoder().encode(Color.red)
+        let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+        #expect(decoded == Color.red)
+    }
+
+    @Test("Encode color with alpha")
+    func encodeWithAlpha() throws {
+        let original = Color(r: 1.0, g: 0.0, b: 0.0, a: 0.5)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+        #expect(decoded.alpha == 0.5)
+        #expect(decoded.red == 1.0)
+    }
+
+    @Test("Encode clear color")
+    func encodeClear() throws {
+        let encoded = try JSONEncoder().encode(Color.clear)
+        let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+        #expect(decoded == Color.clear)
+    }
+
+    @Test("Encode all static colors")
+    func encodeAllStatic() throws {
+        let colors: [Color] = [.black, .white, .red, .green, .blue, .yellow, .cyan, .magenta, .clear, .gray]
+        for color in colors {
+            let encoded = try JSONEncoder().encode(color)
+            let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+            #expect(decoded == color)
+        }
+    }
+
+    @Test("Encode as array")
+    func encodeAsArray() throws {
+        let colors = [Color.red, Color.green, Color.blue]
+        let encoded = try JSONEncoder().encode(colors)
+        let decoded = try JSONDecoder().decode([Color].self, from: encoded)
+        #expect(decoded.count == 3)
+        #expect(decoded[0] == Color.red)
+        #expect(decoded[1] == Color.green)
+        #expect(decoded[2] == Color.blue)
+    }
+
+    @Test("JSON contains expected keys")
+    func jsonKeys() throws {
+        let color = Color(r: 1.0, g: 0.5, b: 0.0, a: 0.8)
+        let encoded = try JSONEncoder().encode(color)
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        #expect(json != nil)
+        // Verify the JSON can be round-tripped
+        let decoded = try JSONDecoder().decode(Color.self, from: encoded)
+        #expect(decoded == color)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+@Suite("CustomStringConvertible Conformance")
+struct StringDescriptionTests {
+    @Test("Opaque color description")
+    func opaqueDescription() {
+        let desc = Color.red.description
+        #expect(desc.contains("Color"))
+        #expect(desc.contains("r:"))
+        #expect(desc.contains("g:"))
+        #expect(desc.contains("b:"))
+        #expect(!desc.contains("a:"))
+    }
+
+    @Test("Color with alpha description includes alpha")
+    func alphaDescription() {
+        let desc = Color.red.withAlpha(0.5).description
+        #expect(desc.contains("a:"))
+        #expect(desc.contains("0.5"))
+    }
+
+    @Test("Clear color description includes alpha")
+    func clearDescription() {
+        let desc = Color.clear.description
+        #expect(desc.contains("a:"))
+    }
+
+    @Test("Description includes actual component values")
+    func descriptionValues() {
+        let color = Color(r: 0.25, g: 0.5, b: 0.75)
+        let desc = color.description
+        #expect(desc.contains("0.25"))
+        #expect(desc.contains("0.5"))
+        #expect(desc.contains("0.75"))
+    }
+
+    @Test("Opaque color has no alpha in description")
+    func opaqueNoAlpha() {
+        let desc = Color.white.description
+        #expect(!desc.contains("a:"))
+    }
+
+    @Test("String interpolation works")
+    func stringInterpolation() {
+        let color = Color.red
+        let str = "Color is: \(color)"
+        #expect(str.contains("Color("))
+    }
+}
+
+// MARK: - Sendable Conformance
+
+@Suite("Sendable Conformance")
+struct SendableTests {
+    @Test("Color is Sendable")
+    func colorSendable() async {
+        // Verify Color can be passed across concurrency boundaries
+        let color = Color.red
+        let result = await Task {
+            return color
+        }.value
+        #expect(result == Color.red)
+    }
+
+    @Test("HSL is Sendable")
+    func hslSendable() async {
+        let hsl = HSL(h: 0, s: 1, l: 0.5)
+        let result = await Task {
+            return hsl
+        }.value
+        #expect(result == HSL(h: 0, s: 1, l: 0.5))
+    }
+
+    @Test("HSV is Sendable")
+    func hsvSendable() async {
+        let hsv = HSV(h: 120, s: 1, v: 1)
+        let result = await Task {
+            return hsv
+        }.value
+        #expect(result == HSV(h: 120, s: 1, v: 1))
+    }
+
+    @Test("LAB is Sendable")
+    func labSendable() async {
+        let lab = LAB(l: 50, a: 25, b: -10)
+        let result = await Task {
+            return lab
+        }.value
+        #expect(result == LAB(l: 50, a: 25, b: -10))
+    }
+
+    @Test("LCH is Sendable")
+    func lchSendable() async {
+        let lch = LCH(l: 50, c: 30, h: 180)
+        let result = await Task {
+            return lch
+        }.value
+        #expect(result == LCH(l: 50, c: 30, h: 180))
+    }
+
+    @Test("NamedColor is Sendable")
+    func namedColorSendable() async {
+        let named = NamedColor.coral
+        let result = await Task {
+            return named
+        }.value
+        #expect(result == NamedColor.coral)
+    }
+
+    @Test("WCAGLevel is Sendable")
+    func wcagLevelSendable() async {
+        let level = WCAGLevel.aa
+        let result = await Task {
+            return level
+        }.value
+        #expect(result == WCAGLevel.aa)
+    }
+
+    @Test("Color can be used in concurrent collection")
+    func colorConcurrentCollection() async {
+        let colors: [Color] = [.red, .green, .blue, .yellow, .cyan]
+        let results = await withTaskGroup(of: Color.self) { group in
+            for color in colors {
+                group.addTask {
+                    return color.withAlpha(0.5)
+                }
+            }
+            var collected: [Color] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+        #expect(results.count == 5)
+        for result in results {
+            #expect(result.alpha == 0.5)
+        }
+    }
+}
+
+// MARK: - WCAGLevel Enum
+
+@Suite("WCAGLevel Enum")
+struct WCAGLevelTests {
+    @Test("AA normal text ratio")
+    func aaNormalText() {
+        #expect(WCAGLevel.aa.normalTextRatio == 4.5)
+    }
+
+    @Test("AA large text ratio")
+    func aaLargeText() {
+        #expect(WCAGLevel.aa.largeTextRatio == 3.0)
+    }
+
+    @Test("AAA normal text ratio")
+    func aaaNormalText() {
+        #expect(WCAGLevel.aaa.normalTextRatio == 7.0)
+    }
+
+    @Test("AAA large text ratio")
+    func aaaLargeText() {
+        #expect(WCAGLevel.aaa.largeTextRatio == 4.5)
+    }
+
+    @Test("AAA is stricter than AA")
+    func aaaStricterThanAA() {
+        #expect(WCAGLevel.aaa.normalTextRatio > WCAGLevel.aa.normalTextRatio)
+        #expect(WCAGLevel.aaa.largeTextRatio > WCAGLevel.aa.largeTextRatio)
+    }
+}
+
+// MARK: - NamedColor Enum Conformances
+
+@Suite("NamedColor Enum Conformances")
+struct NamedColorEnumTests {
+    @Test("NamedColor is CaseIterable")
+    func caseIterable() {
+        #expect(NamedColor.allCases.count == 140)
+    }
+
+    @Test("NamedColor rawValue is hex string")
+    func rawValueIsHex() {
+        #expect(NamedColor.red.rawValue == "FF0000")
+        #expect(NamedColor.blue.rawValue == "0000FF")
+        #expect(NamedColor.green.rawValue == "008000")
+    }
+
+    @Test("NamedColor init from rawValue")
+    func initFromRawValue() {
+        let named = NamedColor(rawValue: "FF0000")
+        #expect(named == .red)
+
+        let invalid = NamedColor(rawValue: "INVALID")
+        #expect(invalid == nil)
+    }
+
+    @Test("NamedColor hex property matches rawValue")
+    func hexMatchesRawValue() {
+        for named in NamedColor.allCases {
+            #expect(named.hex == named.rawValue)
+        }
+    }
+}

--- a/Tests/ColorTests/ColorRGBTests.swift
+++ b/Tests/ColorTests/ColorRGBTests.swift
@@ -1,0 +1,321 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - Core RGB Initialization
+
+@Suite("RGB Double Initialization")
+struct RGBDoubleInitTests {
+    @Test("Standard RGB values")
+    func standardRGB() {
+        let color = Color(r: 0.25, g: 0.5, b: 0.75)
+        #expect(color.red == 0.25)
+        #expect(color.green == 0.5)
+        #expect(color.blue == 0.75)
+        #expect(color.alpha == 1.0)
+    }
+
+    @Test("RGB with explicit alpha")
+    func rgbWithAlpha() {
+        let color = Color(r: 1.0, g: 0.0, b: 0.0, a: 0.5)
+        #expect(color.red == 1.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+        #expect(color.alpha == 0.5)
+    }
+
+    @Test("All zeros produces black")
+    func allZeros() {
+        let color = Color(r: 0.0, g: 0.0, b: 0.0)
+        #expect(color == Color.black)
+    }
+
+    @Test("All ones produces white")
+    func allOnes() {
+        let color = Color(r: 1.0, g: 1.0, b: 1.0)
+        #expect(color == Color.white)
+    }
+
+    @Test("Alpha defaults to 1.0")
+    func defaultAlpha() {
+        let color = Color(r: 0.5, g: 0.5, b: 0.5)
+        #expect(color.alpha == 1.0)
+    }
+}
+
+// MARK: - 8-bit RGB Initialization
+
+@Suite("RGB 8-bit Initialization")
+struct RGB8BitInitTests {
+    @Test("Standard 8-bit values")
+    func standard8Bit() {
+        let color = Color(r: 255, g: 128, b: 0)
+        #expect(color.red == 1.0)
+        #expect(abs(color.green - 128.0 / 255.0) < 0.001)
+        #expect(color.blue == 0.0)
+    }
+
+    @Test("8-bit alpha defaults to 255")
+    func default8BitAlpha() {
+        let color = Color(r: 128, g: 128, b: 128)
+        #expect(color.alpha == 1.0)
+    }
+
+    @Test("8-bit alpha specified")
+    func specified8BitAlpha() {
+        let color = Color(r: 255, g: 0, b: 0, a: 128)
+        #expect(abs(color.alpha - 128.0 / 255.0) < 0.001)
+    }
+
+    @Test("8-bit zero values")
+    func zero8Bit() {
+        let color = Color(r: 0, g: 0, b: 0)
+        #expect(color.red == 0.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+    }
+
+    @Test("8-bit max values")
+    func max8Bit() {
+        let color = Color(r: 255, g: 255, b: 255, a: 255)
+        #expect(color.red == 1.0)
+        #expect(color.green == 1.0)
+        #expect(color.blue == 1.0)
+        #expect(color.alpha == 1.0)
+    }
+
+    @Test("8-bit mid values")
+    func mid8Bit() {
+        let color = Color(r: 128, g: 64, b: 192)
+        #expect(abs(color.red - 128.0 / 255.0) < 0.001)
+        #expect(abs(color.green - 64.0 / 255.0) < 0.001)
+        #expect(abs(color.blue - 192.0 / 255.0) < 0.001)
+    }
+}
+
+// MARK: - Clamping
+
+@Suite("RGB Clamping")
+struct RGBClampingTests {
+    @Test("Values above 1.0 are clamped")
+    func clampAbove() {
+        let color = Color(r: 1.5, g: 2.0, b: 100.0)
+        #expect(color.red == 1.0)
+        #expect(color.green == 1.0)
+        #expect(color.blue == 1.0)
+    }
+
+    @Test("Values below 0.0 are clamped")
+    func clampBelow() {
+        let color = Color(r: -0.5, g: -1.0, b: -100.0)
+        #expect(color.red == 0.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+    }
+
+    @Test("Alpha is also clamped")
+    func clampAlpha() {
+        let above = Color(r: 0.5, g: 0.5, b: 0.5, a: 1.5)
+        #expect(above.alpha == 1.0)
+
+        let below = Color(r: 0.5, g: 0.5, b: 0.5, a: -0.5)
+        #expect(below.alpha == 0.0)
+    }
+
+    @Test("Mixed clamping - some in range, some out")
+    func mixedClamping() {
+        let color = Color(r: 1.5, g: 0.5, b: -0.5, a: 0.75)
+        #expect(color.red == 1.0)
+        #expect(color.green == 0.5)
+        #expect(color.blue == 0.0)
+        #expect(color.alpha == 0.75)
+    }
+
+    @Test("Boundary values are preserved")
+    func boundaryValues() {
+        let color = Color(r: 0.0, g: 1.0, b: 0.0, a: 0.0)
+        #expect(color.red == 0.0)
+        #expect(color.green == 1.0)
+        #expect(color.blue == 0.0)
+        #expect(color.alpha == 0.0)
+    }
+}
+
+// MARK: - 8-bit Component Properties
+
+@Suite("8-bit Component Access")
+struct ComponentAccessTests {
+    @Test("8-bit components for pure colors")
+    func pureColor8Bit() {
+        #expect(Color.red.red8 == 255)
+        #expect(Color.red.green8 == 0)
+        #expect(Color.red.blue8 == 0)
+        #expect(Color.red.alpha8 == 255)
+    }
+
+    @Test("8-bit components for mid-range values")
+    func midRange8Bit() {
+        let color = Color(r: 0.5, g: 0.5, b: 0.5)
+        #expect(color.red8 == 128)
+        #expect(color.green8 == 128)
+        #expect(color.blue8 == 128)
+    }
+
+    @Test("8-bit alpha component")
+    func alpha8Bit() {
+        let color = Color(r: 1.0, g: 0.0, b: 0.0, a: 0.0)
+        #expect(color.alpha8 == 0)
+
+        let halfAlpha = Color(r: 1.0, g: 0.0, b: 0.0, a: 0.5)
+        #expect(halfAlpha.alpha8 == 128)
+    }
+
+    @Test("8-bit boundary rounding")
+    func boundaryRounding() {
+        let color = Color(r: 0.0, g: 0.0, b: 0.0)
+        #expect(color.red8 == 0)
+        #expect(color.green8 == 0)
+        #expect(color.blue8 == 0)
+
+        let white = Color(r: 1.0, g: 1.0, b: 1.0)
+        #expect(white.red8 == 255)
+        #expect(white.green8 == 255)
+        #expect(white.blue8 == 255)
+    }
+}
+
+// MARK: - Static Colors
+
+@Suite("Static Color Constants")
+struct StaticColorTests {
+    @Test("Black is (0,0,0)")
+    func black() {
+        #expect(Color.black.red == 0.0)
+        #expect(Color.black.green == 0.0)
+        #expect(Color.black.blue == 0.0)
+        #expect(Color.black.alpha == 1.0)
+    }
+
+    @Test("White is (1,1,1)")
+    func white() {
+        #expect(Color.white.red == 1.0)
+        #expect(Color.white.green == 1.0)
+        #expect(Color.white.blue == 1.0)
+        #expect(Color.white.alpha == 1.0)
+    }
+
+    @Test("Red is (1,0,0)")
+    func red() {
+        #expect(Color.red.red == 1.0)
+        #expect(Color.red.green == 0.0)
+        #expect(Color.red.blue == 0.0)
+    }
+
+    @Test("Green is (0,1,0)")
+    func green() {
+        #expect(Color.green.red == 0.0)
+        #expect(Color.green.green == 1.0)
+        #expect(Color.green.blue == 0.0)
+    }
+
+    @Test("Blue is (0,0,1)")
+    func blue() {
+        #expect(Color.blue.red == 0.0)
+        #expect(Color.blue.green == 0.0)
+        #expect(Color.blue.blue == 1.0)
+    }
+
+    @Test("Yellow is (1,1,0)")
+    func yellow() {
+        #expect(Color.yellow.red == 1.0)
+        #expect(Color.yellow.green == 1.0)
+        #expect(Color.yellow.blue == 0.0)
+    }
+
+    @Test("Cyan is (0,1,1)")
+    func cyan() {
+        #expect(Color.cyan.red == 0.0)
+        #expect(Color.cyan.green == 1.0)
+        #expect(Color.cyan.blue == 1.0)
+    }
+
+    @Test("Magenta is (1,0,1)")
+    func magenta() {
+        #expect(Color.magenta.red == 1.0)
+        #expect(Color.magenta.green == 0.0)
+        #expect(Color.magenta.blue == 1.0)
+    }
+
+    @Test("Gray is (0.5, 0.5, 0.5)")
+    func gray() {
+        #expect(Color.gray.red == 0.5)
+        #expect(Color.gray.green == 0.5)
+        #expect(Color.gray.blue == 0.5)
+    }
+
+    @Test("Clear has zero alpha")
+    func clear() {
+        #expect(Color.clear.alpha == 0.0)
+        #expect(Color.clear.red == 0.0)
+        #expect(Color.clear.green == 0.0)
+        #expect(Color.clear.blue == 0.0)
+    }
+
+    @Test("Static colors hex values")
+    func staticColorHex() {
+        #expect(Color.black.hex == "#000000")
+        #expect(Color.white.hex == "#FFFFFF")
+        #expect(Color.red.hex == "#FF0000")
+        #expect(Color.green.hex == "#00FF00")
+        #expect(Color.blue.hex == "#0000FF")
+        #expect(Color.yellow.hex == "#FFFF00")
+        #expect(Color.cyan.hex == "#00FFFF")
+        #expect(Color.magenta.hex == "#FF00FF")
+    }
+}
+
+// MARK: - withAlpha
+
+@Suite("withAlpha Method")
+struct WithAlphaTests {
+    @Test("Set alpha on opaque color")
+    func setAlpha() {
+        let color = Color.red.withAlpha(0.5)
+        #expect(color.red == 1.0)
+        #expect(color.green == 0.0)
+        #expect(color.blue == 0.0)
+        #expect(color.alpha == 0.5)
+    }
+
+    @Test("Set alpha to zero")
+    func setAlphaZero() {
+        let color = Color.blue.withAlpha(0.0)
+        #expect(color.alpha == 0.0)
+        #expect(color.blue == 1.0)
+    }
+
+    @Test("Set alpha to one on transparent color")
+    func setAlphaOne() {
+        let clear = Color.clear
+        let opaque = clear.withAlpha(1.0)
+        #expect(opaque.alpha == 1.0)
+    }
+
+    @Test("withAlpha clamps values")
+    func withAlphaClamping() {
+        let above = Color.red.withAlpha(1.5)
+        #expect(above.alpha == 1.0)
+
+        let below = Color.red.withAlpha(-0.5)
+        #expect(below.alpha == 0.0)
+    }
+
+    @Test("withAlpha preserves RGB components")
+    func preservesRGB() {
+        let original = Color(r: 0.2, g: 0.4, b: 0.6)
+        let modified = original.withAlpha(0.3)
+        #expect(modified.red == original.red)
+        #expect(modified.green == original.green)
+        #expect(modified.blue == original.blue)
+    }
+}

--- a/Tests/ColorTests/NamedColorTests.swift
+++ b/Tests/ColorTests/NamedColorTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+@testable import Color
+
+// MARK: - Named Color Creation
+
+@Suite("Named Color Creation")
+struct NamedColorCreationTests {
+    @Test("Create color from named enum")
+    func namedEnum() {
+        let coral = Color.named(.coral)
+        #expect(coral.hex == "#FF7F50")
+    }
+
+    @Test("All primary colors match expected hex")
+    func primaryColors() {
+        #expect(Color.named(.red).hex == "#FF0000")
+        #expect(Color.named(.blue).hex == "#0000FF")
+        #expect(Color.named(.green).hex == "#008000") // CSS green is #008000, not #00FF00
+        #expect(Color.named(.white).hex == "#FFFFFF")
+        #expect(Color.named(.black).hex == "#000000")
+    }
+
+    @Test("Named color property returns valid Color")
+    func namedColorProperty() {
+        let coral = NamedColor.coral
+        let color = coral.color
+        #expect(color.red8 == 0xFF)
+        #expect(color.green8 == 0x7F)
+        #expect(color.blue8 == 0x50)
+    }
+
+    @Test("All named colors produce valid hex colors")
+    func allNamedColorsValid() {
+        for named in NamedColor.allCases {
+            let color = Color(hex: named.hex)
+            #expect(color != nil, "Named color \(named) has invalid hex: \(named.hex)")
+        }
+    }
+
+    @Test("Spot-check various named color hex values")
+    func spotCheckHex() {
+        #expect(NamedColor.indianRed.hex == "CD5C5C")
+        #expect(NamedColor.hotPink.hex == "FF69B4")
+        #expect(NamedColor.gold.hex == "FFD700")
+        #expect(NamedColor.navy.hex == "000080")
+        #expect(NamedColor.teal.hex == "008080")
+        #expect(NamedColor.sienna.hex == "A0522D")
+        #expect(NamedColor.lavender.hex == "E6E6FA")
+        #expect(NamedColor.steelBlue.hex == "4682B4")
+    }
+}
+
+// MARK: - Named Color Aliases
+
+@Suite("Named Color Aliases")
+struct NamedColorAliasTests {
+    @Test("Magenta is alias for fuchsia")
+    func magentaAlias() {
+        #expect(NamedColor.magenta == .fuchsia)
+        #expect(NamedColor.magenta.hex == NamedColor.fuchsia.hex)
+    }
+
+    @Test("Cyan is alias for aqua")
+    func cyanAlias() {
+        #expect(NamedColor.cyan == .aqua)
+        #expect(NamedColor.cyan.hex == NamedColor.aqua.hex)
+    }
+
+    @Test("Fuchsia hex is FF00FF")
+    func fuchsiaHex() {
+        #expect(NamedColor.fuchsia.hex == "FF00FF")
+    }
+
+    @Test("Aqua hex is 00FFFF")
+    func aquaHex() {
+        #expect(NamedColor.aqua.hex == "00FFFF")
+    }
+}
+
+// MARK: - String Name Lookup
+
+@Suite("Named Color String Lookup")
+struct NamedColorLookupTests {
+    @Test("Lookup by exact case name")
+    func exactCase() {
+        let coral = Color(name: "coral")
+        #expect(coral != nil)
+        #expect(coral?.hex == "#FF7F50")
+    }
+
+    @Test("Lookup is case insensitive")
+    func caseInsensitive() {
+        let coral1 = Color(name: "coral")
+        let coral2 = Color(name: "CORAL")
+        let coral3 = Color(name: "Coral")
+        #expect(coral1 != nil)
+        #expect(coral2 != nil)
+        #expect(coral3 != nil)
+        #expect(coral1 == coral2)
+        #expect(coral2 == coral3)
+    }
+
+    @Test("Invalid name returns nil")
+    func invalidName() {
+        #expect(Color(name: "notacolor") == nil)
+        #expect(Color(name: "") == nil)
+        #expect(Color(name: "redd") == nil)
+    }
+
+    @Test("Lookup common CSS colors by name")
+    func commonCSSColors() {
+        #expect(Color(name: "red") != nil)
+        #expect(Color(name: "blue") != nil)
+        #expect(Color(name: "green") != nil)
+        #expect(Color(name: "white") != nil)
+        #expect(Color(name: "black") != nil)
+        #expect(Color(name: "orange") != nil)
+        #expect(Color(name: "purple") != nil)
+        #expect(Color(name: "yellow") != nil)
+    }
+
+    @Test("Lookup camelCase named colors")
+    func camelCaseNames() {
+        #expect(Color(name: "lightCoral") != nil)
+        #expect(Color(name: "darkSlateGray") != nil)
+        #expect(Color(name: "mediumSpringGreen") != nil)
+        #expect(Color(name: "deepSkyBlue") != nil)
+    }
+
+    @Test("Lookup returns correct color for steelBlue")
+    func steelBlueLookup() {
+        let color = Color(name: "steelBlue")
+        #expect(color != nil)
+        #expect(color?.red8 == 0x46)
+        #expect(color?.green8 == 0x82)
+        #expect(color?.blue8 == 0xB4)
+    }
+}
+
+// MARK: - Named Color Categories
+
+@Suite("Named Color Categories")
+struct NamedColorCategoryTests {
+    @Test("Red family colors have high red component")
+    func redFamily() {
+        let reds: [NamedColor] = [.red, .crimson, .fireBrick, .darkRed]
+        for named in reds {
+            let color = named.color
+            #expect(color.red > color.green)
+            #expect(color.red > color.blue)
+        }
+    }
+
+    @Test("Blue family colors have high blue component")
+    func blueFamily() {
+        let blues: [NamedColor] = [.blue, .navy, .darkBlue, .mediumBlue, .midnightBlue]
+        for named in blues {
+            let color = named.color
+            #expect(color.blue >= color.red)
+            #expect(color.blue >= color.green)
+        }
+    }
+
+    @Test("Gray family colors have equal RGB")
+    func grayFamily() {
+        let grays: [NamedColor] = [.gray, .silver, .darkGray, .lightGray, .dimGray]
+        for named in grays {
+            let color = named.color
+            // Grays should have approximately equal R, G, B
+            #expect(abs(color.red - color.green) < 0.05)
+            #expect(abs(color.green - color.blue) < 0.05)
+        }
+    }
+
+    @Test("White family colors are light")
+    func whiteFamily() {
+        let whites: [NamedColor] = [.white, .snow, .ivory, .ghostWhite, .whiteSmoke]
+        for named in whites {
+            let color = named.color
+            #expect(color.luminance > 0.9)
+        }
+    }
+
+    @Test("Total named color count is 140")
+    func totalCount() {
+        #expect(NamedColor.allCases.count == 140)
+    }
+}
+
+// MARK: - Named Color to Color Consistency
+
+@Suite("Named Color Consistency")
+struct NamedColorConsistencyTests {
+    @Test("Named color via enum matches string lookup")
+    func enumMatchesStringLookup() {
+        let enumColor = Color.named(.coral)
+        let stringColor = Color(name: "coral")!
+        #expect(enumColor == stringColor)
+    }
+
+    @Test("Named color hex matches direct hex init")
+    func hexMatchesDirectInit() {
+        for named in NamedColor.allCases {
+            let fromNamed = named.color
+            let fromHex = Color(hex: named.hex)!
+            #expect(fromNamed == fromHex)
+        }
+    }
+
+    @Test("Color.named static method produces same as .color property")
+    func staticMatchesProperty() {
+        for named in NamedColor.allCases {
+            let fromStatic = Color.named(named)
+            let fromProperty = named.color
+            #expect(fromStatic == fromProperty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 6 new test files with ~270 additional tests (total ~350 tests across 7 files)
- Covers the full public API surface of swift-color as a foundational dependency for swift-art, swift-ascii, and swift-godot

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `ColorRGBTests.swift` | 36 | Core RGB init (double & 8-bit), clamping, static colors, withAlpha, 8-bit components |
| `ColorConversionTests.swift` | 58 | HSL/HSV/LAB/LCH conversions, round-trips, struct clamping, achromatic handling, cross-space conversions, deltaE, mixLAB |
| `ColorHexCSSTests.swift` | 35 | Hex parsing (3/4/6/8 char, all prefixes, case), hex output, CSS rgb/rgba, CSS HSL format |
| `ColorProtocolTests.swift` | 43 | Equatable, Hashable (all types), Codable, CustomStringConvertible, Sendable (async Task verification), WCAGLevel, NamedColor enum |
| `ColorEdgeCaseTests.swift` | 73 | Alpha preservation through manipulations/blends, boundary values, blend mode properties, accessibility, color blindness simulation, palette/gradient edge cases |
| `NamedColorTests.swift` | 23 | Named color creation, aliases (magenta/fuchsia, cyan/aqua), string lookup, color categories, consistency between init paths |

## Key Areas Tested

- **All public color types**: Color, HSL, HSV, LAB, LCH, NamedColor, WCAGLevel
- **All color space conversions**: RGB↔HSL, RGB↔HSV, RGB↔LAB↔LCH, cross-space round-trips
- **Protocol conformances**: Sendable (Swift 6 concurrency), Codable, Equatable, Hashable, CustomStringConvertible, CaseIterable
- **Edge cases**: Clamping, alpha preservation, boundary values, achromatic colors, blend mode identities/commutativity
- **Hex/CSS**: All format variants, parsing, output, round-trips

## Test plan
- [x] All test files parse successfully (verified with `swiftc -parse`)
- [ ] CI runs `swift test` on macOS (Xcode) and Ubuntu (swift:6.0)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)