### PR TITLE
Fix NamedColor count assertions (139, not 140)

### DIFF
--- a/Sources/Color/NamedColor.swift
+++ b/Sources/Color/NamedColor.swift
@@ -1,7 +1,9 @@
 /**
  Standard CSS named colors.
 
- All 140 standard web colors as defined by CSS Color Module Level 4.
+ The standard CSS named colors (139 enum cases). `cyan` and `magenta`
+ are provided as static aliases for `aqua` and `fuchsia` respectively,
+ since they share identical hex values.
 
  ```swift
  let color = Color.named(.coral)

--- a/Tests/ColorTests/ColorProtocolTests.swift
+++ b/Tests/ColorTests/ColorProtocolTests.swift
@@ -382,7 +382,7 @@ struct WCAGLevelTests {
 struct NamedColorEnumTests {
     @Test("NamedColor is CaseIterable")
     func caseIterable() {
-        #expect(NamedColor.allCases.count == 140)
+        #expect(NamedColor.allCases.count == 139)
     }
 
     @Test("NamedColor rawValue is hex string")

--- a/Tests/ColorTests/NamedColorTests.swift
+++ b/Tests/ColorTests/NamedColorTests.swift
@@ -182,9 +182,9 @@ struct NamedColorCategoryTests {
         }
     }
 
-    @Test("Total named color count is 140")
+    @Test("Total named color count is 139")
     func totalCount() {
-        #expect(NamedColor.allCases.count == 140)
+        #expect(NamedColor.allCases.count == 139)
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix two failing test assertions that expected `NamedColor.allCases.count == 140` when the actual count is **139**
- The enum has 139 `case` declarations; `cyan` and `magenta` are static computed property aliases for `aqua` and `fuchsia` (they share identical hex values), so `CaseIterable` correctly excludes them
- Update the docstring in `NamedColor.swift` to clarify the alias situation

Fixes #5

## Test plan

- [ ] CI passes on both macOS and Ubuntu (was failing since `a33749d`)
- [ ] All 351 tests pass with the corrected assertions


🤖 Generated with [Claude Code](https://claude.com/claude-code)